### PR TITLE
Added Content-Type headers to prevent HTTP 415 errors

### DIFF
--- a/KashooRequest.php
+++ b/KashooRequest.php
@@ -181,7 +181,9 @@ class KashooRequest {
         } else {
             $headers = array(
                 "Accept: application/json",
+                "Content-Type: application/json",
                 "Authorization: TOKEN uuid:" . self::$_token,
+                "User-Agent: github.com/christophermancini/kashoo-api-client", 
             );
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
             $this->_headers = $headers;


### PR DESCRIPTION
I was having trouble with making POST requests to Kashoo that created entries. It turned out that Kashoo was rejecting the requests because there wasn't a Content-Type header telling it that the request body was in JSON.
